### PR TITLE
Fix: longer URL parsing of owner and repo name

### DIFF
--- a/main/rule_collector.py
+++ b/main/rule_collector.py
@@ -63,7 +63,7 @@ def retrieve_yara_rule_sets(repo_staging_dir, yara_repos):
         # Extract the owner and the repository name from the URL
         repo_url_parts = repo['url'].split("/")
         repo['owner'] = repo_url_parts[3]
-        repo['repo'] = repo_url_parts[4].split(".")[0]
+        repo['repo'] = '/'.join(repo_url_parts[4:]).split(".")[0]
 
         # If the repository hasn't not been cloned yet, clone it
         if not os.path.exists(os.path.join(repo_staging_dir, repo['owner'], repo['repo'])):


### PR DESCRIPTION
Previously, the URL parsing logic assumed a fixed structure for extracting  the repository owner and name, which led to incorrect parsing for certain  Git repository URLs, particularly longer group-based projects hosted on GitLab. 

Issues Fixed:
- problematic extraction of the repository name for long URLs
- Clobbering issue when multiple repositories share a common URL path.

Fix (fixes #46):
- Extract the owner dynamically from index 3.
- Extract the repository name by joining all parts from index 4 onward.

This fix ensures that repository names are correctly captured, even when  they contain multiple path segments, preventing data overwrites.

Example Fix:
For `https://gitlab.example.com/group-a/yara/my-repo.git` 

Previously:
  - `repo['owner'] = 'group-a'`
  - `repo['repo'] = 'yara'` (incorrect)

Now:
  - `repo['owner'] = 'group-a'`
  - `repo['repo'] = 'yara/my-repo'` (correct)