### PR TITLE
Remove rules with elf module from core and extended packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 packages/*
 *.pyc
+*.swp
 yara-forge.log
 repos/*
 yara-forge-rule-issues.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ yara-python
 PyYAML
 gitpython
 git+https://github.com/facebook/pyre2.git@main#egg=fb-re2
+ply

--- a/yara-forge-custom-scoring.yml
+++ b/yara-forge-custom-scoring.yml
@@ -162,6 +162,16 @@ noisy-rules:
     - name: "ESET_Turla_Outlook_Pdf"
       quality: -60
       score: 60
+    # The following rules are ok, but the use the private rule ESET_Apachemodule_PRIVATE which uses the yara module "elf", which slows down the whole scan significantly
+    # so we assign a score of 1 to these rules.
+    - name: "ESET_Apachemodule_PRIVATE"
+      score: 1
+    - name: "ESET_Helimodsteal"
+      score: 1
+    - name: "ESET_Helimodredirect"
+      score: 1
+    - name: "ESET_Helimodproxy"
+      score: 1
 
     # Arkbird SOLG
     - name: "ARKBIRD_SOLG_APT_Lazarus_Loader_Dec_2020_1"

--- a/yara-forge.py
+++ b/yara-forge.py
@@ -5,9 +5,9 @@
 # YARA Forge
 # A YARA Rule Concentrator
 # Florian Roth
-# August 2024
+# July 2025
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 import argparse
 #import pprint
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     print(r'  Bringing Order to Chaos                                 ')
     print(r'                                                          ')
     print(r'  Version %s                                              ' % __version__)
-    print(r'  Florian Roth, January 2024                              ')
+    print(r'  Florian Roth, July 2025                                 ')
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", help="enable debug output", action="store_true")


### PR DESCRIPTION
Code isn't perfect, because there a 3 ESET rules, which need the private rule ESET_Apachemodule_PRIVATE, which uses elf. These don't even end up in the full package because I didn't find a way to do it with reasonable time invest.

