### PR TITLE
score: reduce ELCEEF_Zombie_Malformed_ZIP quality to avoid FPs on Windows system files

### DIFF
--- a/yara-forge-custom-scoring.yml
+++ b/yara-forge-custom-scoring.yml
@@ -130,6 +130,12 @@ noisy-rules:
     - name: "ELASTIC_Linux_Exploit_Dirtycow_8555F149"
       quality: -80
 
+    # Elceef
+    # False positive on Windows system files with malformed ZIP structures (SenseIR.exe, msedge.dll etc.)
+    - name: "ELCEEF_Zombie_Malformed_ZIP"
+      quality: -40
+      score: 50
+
     # FireEye
     - name: "FIREEYE_RT_Hunting_Dotnettojscript_Functions"
       quality: -80


### PR DESCRIPTION
## Summary

Daily false positive testing (2026-03-17) detected 8 matches on legitimate Windows goodware files.

## Affected Files

The rule `ELCEEF_Zombie_Malformed_ZIP` matched on:
- `MsSense.dll` (Windows Defender)
- `SenseIR.exe` (Windows Defender Sensor)
- `msedge.dll` (Microsoft Edge)
- `SenseSampleUploader.exe` (Windows Defender)
- `SenseDlpProcessor.exe` (Windows Defender DLP)
- `SenseTracer.exe` (Windows Defender)
- `RunPsScript.dll` (Windows Defender)
- Additional system files in Windows 11 24H2 WinSxS

## Root Cause

The rule detects malformed ZIP structures, but these legitimate Microsoft binaries contain embedded archives (likely for self-extraction or resource storage) that trigger the detection.

## Changes

```yaml
- name: "ELCEEF_Zombie_Malformed_ZIP"
  quality: -40
  score: 50
```

## Testing

- Scanned against ~35GB goodware corpus including Windows 11 24H2 system files
- Build completed successfully with 9750 rules
- Total FP matches reduced from baseline
