### PR TITLE
score: Reduce quality for DELIVRTO_SUSP_SVG_Foreignobject_Nov24 (Gatsby FPs)

### DIFF
--- a/yara-forge-custom-scoring.yml
+++ b/yara-forge-custom-scoring.yml
@@ -375,6 +375,10 @@ noisy-rules:
       quality: -80
     - name: "DELIVRTO_SUSP_ZIP_Smuggling_Egg_Jun01"
       quality: -80
+    # 3 FPs on Gatsby npm package (2026-04-01)
+    - name: "DELIVRTO_SUSP_SVG_Foreignobject_Nov24"
+      quality: -20
+      score: 60
 
     # SecuInfra
     - name: "SECUINFRA_OBFUS_Powershell_Common_Replace"


### PR DESCRIPTION
## Summary

Scoring adjustment for 1 rule causing false positives on legitimate goodware.

**Certutil_Decode_OR_Download** was removed from this PR — fixed at source in Neo23x0/signature-base#396 with an FP exclusion string. Confirmed zero certutil FPs in today's rebuild.

## Rule Adjusted

| Rule | FPs | Quality | Score | Matched Files |
|------|-----|---------|-------|---------------|
| `DELIVRTO_SUSP_SVG_Foreignobject_Nov24` | 3 | -20 | 60 | Gatsby npm package SVG files |

## Verification

- Rebuilt YARA-Forge from master after signature-base fix was merged
- **Certutil FPs: 0** (was 8) ✅
- **DelivrTo FPs: 3** (unchanged, needs scoring adjustment)
- Total FPs: 246 (down from 253)

---
*Generated by automated YARA-Forge daily build testing*