### PR TITLE
fix: FP adjustment - DELIVRTO_SUSP_SVG_Foreignobject_Nov24

### DIFF
--- a/yara-forge-custom-scoring.yml
+++ b/yara-forge-custom-scoring.yml
@@ -375,6 +375,9 @@ noisy-rules:
       quality: -80
     - name: "DELIVRTO_SUSP_ZIP_Smuggling_Egg_Jun01"
       quality: -80
+    - name: "DELIVRTO_SUSP_SVG_Foreignobject_Nov24"
+      quality: -20
+      score: 60
 
     # SecuInfra
     - name: "SECUINFRA_OBFUS_Powershell_Common_Replace"


### PR DESCRIPTION
## False Positive Adjustment — 2026-05-11

### Summary
Daily goodware FP test identified 1 new rule requiring scoring adjustment.

### New Adjustment

| Rule | FP Matches | Quality | Score |
|------|-----------|---------|-------|
| `DELIVRTO_SUSP_SVG_Foreignobject_Nov24` | 3 | -20 | 60 |

**Rationale:** This rule matches on SVG files containing `<foreignObject>` elements, which are commonly used in legitimate web content and benign SVG files. The 3 goodware matches confirm moderate FP tendency. Reducing quality to -20 and capping score at 60 de-prioritizes it in production without disabling detection.

### Already Scored (No Changes)
8 rules were already in `yara-forge-custom-scoring.yml` and remain unchanged:
- DITEKSHEN_INDICATOR_SUSPICIOUS_EXE_Reversed (189 matches)
- DITEKSHEN_INDICATOR_SUSPICIOUS_EXE_Regkeycomb_Disablewindefender (32)
- DITEKSHEN_INDICATOR_SUSPICIOUS_EXE_Nonewindowsua (13)
- SECUINFRA_SUS_Unsigned_APPX_MSIX_Installer_Feb23 (3)
- DITEKSHEN_INDICATOR_SUSPICIOUS_EXE_References_Confidential_Data_Store (2)
- SECUINFRA_SUSP_Powershell_Base64_Decode (1)
- MALPEDIA_Win_Squidloader_Auto (1)
- GODMODERULES_IDDQD_God_Mode_Rule (1)

### Build Stats
- **Commit:** c227abd
- **Total Rules:** 9,713
- **Total FP Matches:** 245
- **Build Duration:** ~22 min